### PR TITLE
Fixing Cake.FileHelpers addin version

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,6 @@
 #tool "nuget:?package=NUnit.Runners&version=2.6.4"
 #tool "nuget:?package=ILRepack"
-#addin "Cake.FileHelpers"
+#addin "Cake.FileHelpers&version=1.0.4"
 #addin "Cake.Incubator&version=1.0.56"
 #load "cake.scripts/utilities.cake"
 


### PR DESCRIPTION
The new version of that addin depends on .Net 4.6