### PR TITLE
fix issues with websocket

### DIFF
--- a/ReactiveXComponent/Connection/IXCPublisher.cs
+++ b/ReactiveXComponent/Connection/IXCPublisher.cs
@@ -7,6 +7,7 @@ namespace ReactiveXComponent.Connection
 {
     public interface IXCPublisher : IDisposable
     {
+        void SendEvent(string stateMachine, object message, string messageType, Visibility visibility = Visibility.Public);
         void SendEvent(string stateMachine, object message, Visibility visibility = Visibility.Public);
         void SendEvent(StateMachineRefHeader stateMachineRefHeader, object message, Visibility visibility = Visibility.Public);
         List<MessageEventArgs> GetSnapshot(string stateMachine, int timeout = 10000);

--- a/ReactiveXComponent/RabbitMq/RabbitMqPublisher.cs
+++ b/ReactiveXComponent/RabbitMq/RabbitMqPublisher.cs
@@ -32,9 +32,9 @@ namespace ReactiveXComponent.RabbitMq
 
         #region IXCPublisher implementation
 
-        public void SendEvent(string stateMachine, object message, Visibility visibility = Visibility.Public)
+        public void SendEvent(string stateMachine, object message, string messageType, Visibility visibility = Visibility.Public)
         {
-            var header = CreateHeader(_component, stateMachine, message, visibility);
+            var header = CreateHeader(_component, stateMachine, message, messageType, visibility);
 
             if (header == null) return;
 
@@ -45,6 +45,11 @@ namespace ReactiveXComponent.RabbitMq
             message = message ?? 0;
 
             Send(message, routingKey, prop);
+        }
+
+        public void SendEvent(string stateMachine, object message, Visibility visibility = Visibility.Public)
+        {
+            SendEvent(stateMachine, message, message?.GetType().ToString() ?? string.Empty, visibility);
         }
 
         public void SendEvent(StateMachineRefHeader stateMachineRefHeader, object message, Visibility visibility = Visibility.Public)
@@ -87,10 +92,9 @@ namespace ReactiveXComponent.RabbitMq
             _publisherChannel.ExchangeDeclare(_exchangeName, ExchangeType.Topic);
         }
 
-        private Header CreateHeader(string component, string stateMachine, object message, Visibility visibility)
+        private Header CreateHeader(string component, string stateMachine, object message, string messageType, Visibility visibility)
         {
             var defaultValue = -1;
-            var messageType = message?.GetType().ToString() ?? string.Empty;
 
             if (_configuration == null)
             {

--- a/ReactiveXComponent/WebSocket/WebSocketPublisher.cs
+++ b/ReactiveXComponent/WebSocket/WebSocketPublisher.cs
@@ -27,17 +27,22 @@ namespace ReactiveXComponent.WebSocket
 
         public void SendEvent(string stateMachine, object message, Visibility visibility = Visibility.Public)
         {
+            SendEvent(stateMachine, message, message?.GetType().ToString(), visibility);
+        }
+
+        public void SendEvent(string stateMachine, object message, string messageType, Visibility visibility = Visibility.Public)
+        {
             if (!_webSocketClient.IsOpen) return;
-            
-            var inputHeader = CreateWebSocketHeader(stateMachine, message, visibility);
+
+            var inputHeader = CreateWebSocketHeader(stateMachine, messageType, visibility);
             var componentCode = _xcConfiguration.GetComponentCode(_component);
             var topic = _xcConfiguration.GetPublisherTopic(_component, stateMachine);
             var webSocketRequest = WebSocketMessageHelper.SerializeRequest(
-                    WebSocketCommand.Input,
-                    inputHeader,
-                    message,
-                    componentCode.ToString(),
-                    topic);
+                WebSocketCommand.Input,
+                inputHeader,
+                message,
+                componentCode.ToString(),
+                topic);
 
             _webSocketClient.Send(webSocketRequest);
         }
@@ -71,15 +76,14 @@ namespace ReactiveXComponent.WebSocket
 
         #endregion
 
-        private WebSocketEngineHeader CreateWebSocketHeader(string stateMachine, object message, Visibility visibility = Visibility.Public)
+        private WebSocketEngineHeader CreateWebSocketHeader(string stateMachine, string messageType, Visibility visibility = Visibility.Public)
         {
-            var messageType = message?.GetType();
             var webSocketEngineHeader = new WebSocketEngineHeader
             {
                 ComponentCode = _xcConfiguration.GetComponentCode(_component),
                 StateMachineCode = _xcConfiguration.GetStateMachineCode(_component, stateMachine),
-                EventCode = _xcConfiguration.GetPublisherEventCode(messageType?.ToString()),
-                MessageType = messageType?.ToString(),
+                EventCode = _xcConfiguration.GetPublisherEventCode(messageType),
+                MessageType = messageType,
                 PublishTopic = visibility == Visibility.Private && !string.IsNullOrEmpty(_privateCommunicationIdentifier)? _privateCommunicationIdentifier : null
             };
 

--- a/ReactiveXComponent/WebSocket/WebSocketXCApiManager.cs
+++ b/ReactiveXComponent/WebSocket/WebSocketXCApiManager.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
 using System.Reactive;
 using System.Reactive.Linq;
+using System.Text;
 using System.Threading;
 using Newtonsoft.Json;
 using ReactiveXComponent.Common;
@@ -62,8 +65,28 @@ namespace ReactiveXComponent.WebSocket
 
             return result;
         }
+     
+        private string unzipString(byte[] data)
 
+        {
 
+            MemoryStream memory = new MemoryStream(data, false);
+
+            // gzip wraps around memory stream, data read with gzip is decompressed from memory stream
+
+            GZipStream gzip = new GZipStream(memory, CompressionMode.Decompress);
+
+            StreamReader rdr = new StreamReader(gzip, Encoding.UTF8);
+
+            string sUnzipped = rdr.ReadToEnd();
+
+            ;
+
+            return sUnzipped;
+
+        }
+
+      
         public string GetXCApi(string apiFullName, string requestId = null, TimeSpan ? timeout = null)
         {
             var delay = timeout ?? TimeSpan.FromSeconds(10);
@@ -73,7 +96,7 @@ namespace ReactiveXComponent.WebSocket
             {
                 if (response.RequestId == requestId && response.ApiFound)
                 {
-                    result = response.ApiName;
+                    result = unzipString(Convert.FromBase64String(response.Content));
                     lockEvent.Set();
                 }
             });

--- a/ReactiveXComponent/WebSocket/WebSocketXCApiManager.cs
+++ b/ReactiveXComponent/WebSocket/WebSocketXCApiManager.cs
@@ -66,24 +66,14 @@ namespace ReactiveXComponent.WebSocket
             return result;
         }
      
-        private string unzipString(byte[] data)
-
+        private string UnzipString(byte[] data)
         {
-
-            MemoryStream memory = new MemoryStream(data, false);
-
-            // gzip wraps around memory stream, data read with gzip is decompressed from memory stream
-
-            GZipStream gzip = new GZipStream(memory, CompressionMode.Decompress);
-
-            StreamReader rdr = new StreamReader(gzip, Encoding.UTF8);
-
-            string sUnzipped = rdr.ReadToEnd();
-
-            ;
-
-            return sUnzipped;
-
+            using (var memoryStream = new MemoryStream(data, false))
+            using (var gzipStream = new GZipStream(memoryStream, CompressionMode.Decompress))
+            using (var reader = new StreamReader(gzipStream, Encoding.UTF8))
+            {
+                return reader.ReadToEnd();
+            }
         }
 
       
@@ -96,10 +86,11 @@ namespace ReactiveXComponent.WebSocket
             {
                 if (response.RequestId == requestId && response.ApiFound)
                 {
-                    result = unzipString(Convert.FromBase64String(response.Content));
+                    result = UnzipString(Convert.FromBase64String(response.Content));
                     lockEvent.Set();
                 }
             });
+            
             var request = new WebSocketXCApiCommand
             {
                 Command = WebSocketCommand.GetXCApi,

--- a/ReactiveXComponent/XComponentApi.cs
+++ b/ReactiveXComponent/XComponentApi.cs
@@ -3,6 +3,7 @@ using ReactiveXComponent.Common;
 using ReactiveXComponent.Configuration;
 using ReactiveXComponent.Connection;
 using ReactiveXComponent.Parser;
+using ReactiveXComponent.WebSocket;
 
 namespace ReactiveXComponent
 {
@@ -20,6 +21,16 @@ namespace ReactiveXComponent
             _xcConnection = connectionFactory.CreateConnection(connectionType);
         }
 
+        private XComponentApi(Stream xcApiStream, WebSocketEndpoint webSocketEndpoint, string privateCommunicationIdentifier = null)
+        {
+            var parser = new XCApiConfigParser();
+            var xcConfiguration = new XCConfiguration(parser);
+            xcConfiguration.Init(xcApiStream);
+            _xcConnection = new WebSocketConnection(xcConfiguration, webSocketEndpoint, 10000, privateCommunicationIdentifier);
+        }
+
+
+
         public static IXComponentApi CreateFromXCApi(string xcApiFilePath, string privateCommunicationIdentifier = null)
         {
             if (!File.Exists(xcApiFilePath))
@@ -36,6 +47,11 @@ namespace ReactiveXComponent
         public static IXComponentApi CreateFromXCApi(Stream xcApiStream, string privateCommunicationIdentifier = null)
         {
             return new XComponentApi(xcApiStream, privateCommunicationIdentifier);
+        }
+
+        public static IXComponentApi CreateFromXCApi(Stream xcApiStream, WebSocketEndpoint webSocketEndpoint, string privateCommunicationIdentifier = null)
+        {
+            return new XComponentApi(xcApiStream, webSocketEndpoint, privateCommunicationIdentifier);
         }
 
         public IXCSession CreateSession(ConfigurationOverrides configurationOverrides = null)


### PR DESCRIPTION
Several issues:
1. GetXCApi  : doesn't return the xcApi file content
2. It is not possible to specify the message type on the sendEvent method. In this case, you need to have the same user objects on clients and server side. Eg with message type on sendEvent, we can create anonymous types on client side:
   var sayHello = new
                    {
                        Name = "myName",
                        RequestId = Guid.NewGuid().ToString()
                    };
                    publisher.SendEvent("Hello", sayHello, "XComponent.Hello.UserObject.SayHello");
3. When an embedded client api is loaded by a websocket bridge there's no information about the connection in the xcAPi. So there's the need to create an IXcomponentApi from an endpoint:

 IXComponentApi xcApi =
                        XComponentApi.CreateFromXCApi(stream
                         , new WebSocketEndpoint(null, "127.0.0.1", "9880", WebSocketType.Plain)) ;
