### PR TITLE
Changing Circle Ci build status badge style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![ReactiveXComponent.Net Nuget](https://img.shields.io/nuget/v/ReactiveXComponent.Net.svg)](https://www.nuget.org/packages/ReactiveXComponent.Net)  [![ReactiveXComponent.Net Downloads](https://img.shields.io/nuget/dt/ReactiveXComponent.Net.svg)](https://www.nuget.org/packages/ReactiveXComponent.Net) [![CircleCI](https://circleci.com/gh/xcomponent/ReactiveXComponent.Net.svg?style=shield)](https://circleci.com/gh/xcomponent/ReactiveXComponent.Net) [![XComponent Slack](http://slack.xcomponent.com/badge.svg)](http://slack.xcomponent.com/)
+[![ReactiveXComponent.Net Nuget](https://img.shields.io/nuget/v/ReactiveXComponent.Net.svg)](https://www.nuget.org/packages/ReactiveXComponent.Net)  [![ReactiveXComponent.Net Downloads](https://img.shields.io/nuget/dt/ReactiveXComponent.Net.svg)](https://www.nuget.org/packages/ReactiveXComponent.Net) [![CircleCI](https://circleci.com/gh/xcomponent/ReactiveXComponent.Net.svg?style=shield)](https://circleci.com/gh/xcomponent/ReactiveXComponent.Net) [![XComponent team Slack](http://slack.xcomponent.com/badge.svg)](http://slack.xcomponent.com/)
 
 # .Net Reactive XComponent API
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![ReactiveXComponent.Net Nuget](https://img.shields.io/nuget/v/ReactiveXComponent.Net.svg)](https://www.nuget.org/packages/ReactiveXComponent.Net)  [![ReactiveXComponent.Net Downloads](https://img.shields.io/nuget/dt/ReactiveXComponent.Net.svg)](https://www.nuget.org/packages/ReactiveXComponent.Net) [![CircleCI](https://circleci.com/gh/xcomponent/ReactiveXComponent.Net.svg?style=svg)](https://circleci.com/gh/xcomponent/ReactiveXComponent.Net) [![](http://slack.xcomponent.com/badge.svg)](http://slack.xcomponent.com/)
+[![ReactiveXComponent.Net Nuget](https://img.shields.io/nuget/v/ReactiveXComponent.Net.svg)](https://www.nuget.org/packages/ReactiveXComponent.Net)  [![ReactiveXComponent.Net Downloads](https://img.shields.io/nuget/dt/ReactiveXComponent.Net.svg)](https://www.nuget.org/packages/ReactiveXComponent.Net) [![CircleCI](https://circleci.com/gh/xcomponent/ReactiveXComponent.Net.svg?style=shield)](https://circleci.com/gh/xcomponent/ReactiveXComponent.Net) [![XComponent Slack](http://slack.xcomponent.com/badge.svg)](http://slack.xcomponent.com/)
 
 # .Net Reactive XComponent API
 


### PR DESCRIPTION
Changing Circle Ci build status badge style to match the rest of the badges (shield).

[Old style](https://circleci.com/gh/xcomponent/ReactiveXComponent.Net.svg?style=svg)
[New style](https://circleci.com/gh/xcomponent/ReactiveXComponent.Net.svg?style=shield)